### PR TITLE
chore: refactor storage

### DIFF
--- a/internal/ports/models/commands/commands.go
+++ b/internal/ports/models/commands/commands.go
@@ -5,11 +5,19 @@ import (
 )
 
 type Commands struct {
-	Storage *domain_crl.Storage
+	storage *domain_crl.Storage
 }
 
 func NewCommands(storage *domain_crl.Storage) *Commands {
 	return &Commands{
-		Storage: storage,
+		storage: storage,
 	}
+}
+
+func (c *Commands) CacheDir() string {
+	return c.storage.CacheDir()
+}
+
+func (c *Commands) ImportDir() string {
+	return c.storage.ImportDir()
 }

--- a/internal/ports/models/commands/crl.go
+++ b/internal/ports/models/commands/crl.go
@@ -30,7 +30,7 @@ func (c *Commands) GetCRL(url *url.URL) tea.Cmd {
 			}
 		}
 
-		err = domain_crl.Process(ctx, url, revocationList, domain_crl.GlobalStorage)
+		err = domain_crl.Process(ctx, url, revocationList, c.storage)
 		if err != nil {
 			return nil
 		}
@@ -63,7 +63,7 @@ func (c *Commands) LoadCRL(path string) tea.Cmd {
 			}
 		}
 
-		err = domain_crl.Process(ctx, nil, revocationList, domain_crl.GlobalStorage)
+		err = domain_crl.Process(ctx, nil, revocationList, c.storage)
 		if err != nil {
 			return nil
 		}
@@ -77,7 +77,7 @@ func (c *Commands) LoadCRL(path string) tea.Cmd {
 func (c *Commands) GetCRLsFromStore() tea.Msg {
 	log.Println("requesting CRLs from store")
 	ctx := context.Background()
-	cRLs, err := domain_crl.GlobalStorage.Repository.List(ctx)
+	cRLs, err := c.storage.Repository.List(ctx)
 	if err != nil {
 		return nil
 	}
@@ -98,7 +98,7 @@ func (c *Commands) DeleteCRLFromStore(id string) tea.Cmd {
 				Err: errors.Join(errors.New("could not parse CRL ID, to be used for deletion"), err),
 			}
 		}
-		err = domain_crl.GlobalStorage.Repository.Delete(ctx, dbID)
+		err = c.storage.Repository.Delete(ctx, dbID)
 		if err != nil {
 			log.Println("could not delete CRL")
 			return messages.ErrorMsg{

--- a/internal/ports/models/commands/revoked_certificate.go
+++ b/internal/ports/models/commands/revoked_certificate.go
@@ -63,7 +63,7 @@ func (c *Commands) GetRevokedCertificates(args *GetRevokedCertificatesArgs) tea.
 			}
 		}
 
-		certificates, err := crl.GlobalStorage.Repository.FindRevokedCertificates(ctx, ID)
+		certificates, err := c.storage.Repository.FindRevokedCertificates(ctx, ID)
 		if err != nil {
 			log.Printf("could not retrieve revoked certificates: %v", err)
 			return messages.ErrorMsg{

--- a/internal/ports/models/import.go
+++ b/internal/ports/models/import.go
@@ -10,7 +10,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/pimg/certguard/internal/ports/models/commands"
 	"github.com/pimg/certguard/internal/ports/models/styles"
-	"github.com/pimg/certguard/pkg/domain/crl"
 )
 
 // keyMap defines a set of keybindings. To work for help it must satisfy
@@ -70,7 +69,7 @@ func NewImportModel(cmds *commands.Commands) *ImportModel {
 	fp.Styles.Cursor = browseStyle.FilePickerFile
 	fp.KeyMap.Back = key.NewBinding(key.WithKeys("h", "backspace", "left"), key.WithHelp("h", "back"))
 
-	fp.CurrentDirectory = crl.GlobalStorage.ImportDir()
+	fp.CurrentDirectory = cmds.ImportDir()
 
 	return &ImportModel{
 		keys:       importKeys,

--- a/pkg/domain/crl/storage.go
+++ b/pkg/domain/crl/storage.go
@@ -25,11 +25,8 @@ func NewStorage(repository Repository, baseDir string) (*Storage, error) {
 		Repository: repository,
 		baseDir:    baseDir,
 	}
-	GlobalStorage = storage
 	return storage, nil
 }
-
-var GlobalStorage *Storage
 
 func (s *Storage) CacheDir() string {
 	return s.baseDir


### PR DESCRIPTION
storage no longer uses a global variable, but is embedded in a commands struct. Commands are methods on the commands struct. References of the commands struct are available on the models that issue commands

Issue: #92