### PR TITLE
fix: create certguard directory if it not exists

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,14 @@ func runInteractiveCertGuard(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		err := os.MkdirAll(cacheDir, 0o775)
+		if err != nil {
+			fmt.Println("fatal:", err)
+			os.Exit(1)
+		}
+	}
+
 	dbConnection, err := db.NewDBConnection(cacheDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Issue: #116