### PR TITLE
chore: change deprecated linter for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 
 @PHONY: lint
 lint:
-	golangci-lint run --out-format=github-actions
+	golangci-lint run --out-format=colored-line-number
 
 @PHONY: build
 build:


### PR DESCRIPTION
the golangci-lint linter 'github-actions' is deprecated, this is changed to 'colored-line-number'.

Issue: #132